### PR TITLE
Reenable crypto-enigma package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4951,7 +4951,7 @@ packages:
       - hslua-module-text < 0.3
 
       # https://github.com/commercialhaskell/stackage/issues/5603
-      - crypto-enigma < 0 # base 4.14.1.0
+      - crypto-enigma < 0
 
 # end of packages
 


### PR DESCRIPTION
Re-enable `crypto-enigma` package following update to bounds in Hackage package info

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $pacakge # or $package-$version

The script runs virtually the following commands in a clean directory (also run successfully):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
